### PR TITLE
LoggingHandler takes logger name

### DIFF
--- a/stable_map/handlers/info.py
+++ b/stable_map/handlers/info.py
@@ -14,13 +14,13 @@ class LoggingHandler(ErrorHandler[Any, Exception]):
 
     def __init__(
         self,
-        logger: logging.Logger | None = None,
-        message_format: str = '{index} element failed. Value={element}',
+        logger: logging.Logger | str | None = None,
+        message_format: str = "{index} element failed. Value={element}",
         exceptions: Sequence[type[Exception]] = [Exception],
         ignore: Sequence[type[Exception]] = [],
     ) -> None:
-        if logger is None:
-            logger = logging.getLogger(__name__)
+        if not isinstance(logger, logging.Logger):
+            logger = logging.getLogger(logger)
 
         super().__init__(exceptions, ignore)
         self.__logger = logger


### PR DESCRIPTION
Close #29

Also fixed was a bug where, if you did not explicitly pass a `logger` to the `LoggingHandler`, the logger of the `stable_map.handlers.info` module was used

---

Также исправлена ошибка, при которой если явно не передать в `LoggingHandler` логгер, использовался логгер модуля `stable_map.handlers.info`